### PR TITLE
Update known-users.yml

### DIFF
--- a/known-users.yml
+++ b/known-users.yml
@@ -17,6 +17,7 @@ e-lo: Elizabeth Sall
 gregerhardt: Gregory Erhardt
 gregmacfarlane: Greg Macfarlane
 gregorbj: Brian Gregor
+janzill: Jan Zill
 jfdman: Joel Freedman
 jkpdunbar: Julie Dunbar
 JoeJimFlood: Joe Flood


### PR DESCRIPTION
Jan has made two key contributions to open-source in our industry:

* Equilibrium assignment in AequilibraE (merged and in use for many years)
* Methodology for reducing random noise in ActivitySim models (recently presented to the ActivitySim consortium)